### PR TITLE
Documentation: fill in missing parameter comments

### DIFF
--- a/Emulator/RIoT/RIoTCrypt/RiotCrypt.c
+++ b/Emulator/RIoT/RIoTCrypt/RiotCrypt.c
@@ -164,12 +164,12 @@ RiotCrypt_Hmac2(
 
 RIOT_STATUS
 RiotCrypt_DeriveEccKey(
-    RIOT_ECC_PUBLIC    *publicPart,     // OUT: TODO
-    RIOT_ECC_PRIVATE   *privatePart,    // OUT: TODO
-    const void         *srcData,        // IN:  TODO
-    size_t              srcDataSize,    // IN:  TODO
-    const uint8_t      *label,          // IN:  TODO
-    size_t              labelSize       // IN:  TODO
+    RIOT_ECC_PUBLIC    *publicPart,     // OUT: Derived public key
+    RIOT_ECC_PRIVATE   *privatePart,    // OUT: Derived private key
+    const void         *srcData,        // IN:  Initial data for derivation
+    size_t              srcDataSize,    // IN:  Size of the source data in bytes
+    const uint8_t      *label,          // IN:  Label for derivation (may be NULL)
+    size_t              labelSize       // IN:  Size of the label in bytes
 )
 {
     bigval_t    srcVal  = { 0 };
@@ -192,9 +192,9 @@ RiotCrypt_DeriveEccKey(
 
 void
 RiotCrypt_ExportEccPub(
-    RIOT_ECC_PUBLIC     *a,     // IN:  TODO
-    uint8_t             *b,     // OUT: TODO
-    uint32_t            *s      // OUT: TODO
+    RIOT_ECC_PUBLIC     *a,     // IN:  ECC Public Key to export
+    uint8_t             *b,     // OUT: Buffer to receive the public key
+    uint32_t            *s      // OUT: Pointer to receive the buffer size (may be NULL)
 )
 {
     *b++ = 0x04;
@@ -209,10 +209,10 @@ RiotCrypt_ExportEccPub(
 
 RIOT_STATUS
 RiotCrypt_Sign(
-    RIOT_ECC_SIGNATURE     *sig,        // OUT: TODO
-    const void             *data,       // IN:  TODO
-    size_t                  dataSize,   // IN:  TODO
-    const RIOT_ECC_PRIVATE *key         // IN:  TODO
+    RIOT_ECC_SIGNATURE     *sig,        // OUT: Signature of data
+    const void             *data,       // IN:  Data to sign
+    size_t                  dataSize,   // IN:  Data size in bytes
+    const RIOT_ECC_PRIVATE *key         // IN:  Signing key
 )
 {
     uint8_t digest[RIOT_DIGEST_LENGTH];
@@ -224,10 +224,10 @@ RiotCrypt_Sign(
 
 RIOT_STATUS
 RiotCrypt_SignDigest(
-    RIOT_ECC_SIGNATURE     *sig,            // OUT: TODO
-    const uint8_t          *digest,         // IN:  TODO
-    size_t                  digestSize,     // IN:  TODO
-    const RIOT_ECC_PRIVATE *key             // IN:  TODO
+    RIOT_ECC_SIGNATURE     *sig,            // OUT: Signature of digest
+    const uint8_t          *digest,         // IN:  Digest to sign
+    size_t                  digestSize,     // IN:  Size of the digest in bytes
+    const RIOT_ECC_PRIVATE *key             // IN:  Signing key
 )
 {
     if (digestSize != RIOT_DIGEST_LENGTH) {
@@ -239,10 +239,10 @@ RiotCrypt_SignDigest(
 
 RIOT_STATUS
 RiotCrypt_Verify(
-    const void                 *data,       // IN: TODO
-    size_t                      dataSize,   // IN: TODO
-    const RIOT_ECC_SIGNATURE   *sig,        // IN: TODO
-    const RIOT_ECC_PUBLIC      *key         // IN: TODO
+    const void                 *data,       // IN: Data to verify signature of
+    size_t                      dataSize,   // IN: Size of data in bytes
+    const RIOT_ECC_SIGNATURE   *sig,        // IN: Signature to verify
+    const RIOT_ECC_PUBLIC      *key         // IN: ECC public key of signer
 )
 {
     uint8_t digest[RIOT_DIGEST_LENGTH];
@@ -254,10 +254,10 @@ RiotCrypt_Verify(
 
 RIOT_STATUS
 RiotCrypt_VerifyDigest(
-    const uint8_t              *digest,     // IN: TODO
-    size_t                      digestSize, // IN: TODO
-    const RIOT_ECC_SIGNATURE   *sig,        // IN: TODO
-    const RIOT_ECC_PUBLIC      *key         // IN: TODO
+    const uint8_t              *digest,     // IN: Digest to verify signature of
+    size_t                      digestSize, // IN: Size of the digest
+    const RIOT_ECC_SIGNATURE   *sig,        // IN: Signature to verify
+    const RIOT_ECC_PUBLIC      *key         // IN: ECC public key of signer
 )
 {
     if (digestSize != RIOT_DIGEST_LENGTH) {

--- a/Emulator/RIoT/RIoTCrypt/include/RiotCrypt.h
+++ b/Emulator/RIoT/RIoTCrypt/include/RiotCrypt.h
@@ -134,51 +134,51 @@ RiotCrypt_Hmac2(
 
 RIOT_STATUS
 RiotCrypt_DeriveEccKey(
-    RIOT_ECC_PUBLIC    *publicPart,     // OUT: TODO
-    RIOT_ECC_PRIVATE   *privatePart,    // OUT: TODO
-    const void         *srcData,        // IN:  TODO
-    size_t              srcDataSize,    // IN:  TODO
-    const uint8_t      *label,          // IN:  TODO
-    size_t              labelSize       // IN:  TODO
+    RIOT_ECC_PUBLIC    *publicPart,     // OUT: Derived public key
+    RIOT_ECC_PRIVATE   *privatePart,    // OUT: Derived private key
+    const void         *srcData,        // IN:  Initial data for derivation
+    size_t              srcDataSize,    // IN:  Size of the source data in bytes
+    const uint8_t      *label,          // IN:  Label for derivation (may be NULL)
+    size_t              labelSize       // IN:  Size of the label in bytes
 );
 
 void
 RiotCrypt_ExportEccPub(
-    RIOT_ECC_PUBLIC     *a,     // IN:  TODO
-    uint8_t             *b,     // OUT: TODO
-    uint32_t            *s      // OUT: TODO
+    RIOT_ECC_PUBLIC     *a,     // IN:  ECC Public Key to export
+    uint8_t             *b,     // OUT: Buffer to receive the public key
+    uint32_t            *s      // OUT: Pointer to receive the buffer size (may be NULL)
 );
 
 RIOT_STATUS
 RiotCrypt_Sign(
-    RIOT_ECC_SIGNATURE     *sig,        // OUT: TODO
-    const void             *data,       // IN:  TODO
-    size_t                  dataSize,   // IN:  TODO
-    const RIOT_ECC_PRIVATE *key         // IN:  TODO
+    RIOT_ECC_SIGNATURE     *sig,        // OUT: Signature of data
+    const void             *data,       // IN:  Data to sign
+    size_t                  dataSize,   // IN:  Data size in bytes
+    const RIOT_ECC_PRIVATE *key         // IN:  Signing key
 );
 
 RIOT_STATUS
 RiotCrypt_SignDigest(
-    RIOT_ECC_SIGNATURE     *sig,            // OUT: TODO
-    const uint8_t          *digest,         // IN:  TODO
-    size_t                  digestSize,     // IN:  TODO
-    const RIOT_ECC_PRIVATE *key             // IN:  TODO
+    RIOT_ECC_SIGNATURE     *sig,            // OUT: Signature of digest
+    const uint8_t          *digest,         // IN:  Digest to sign
+    size_t                  digestSize,     // IN:  Size of the digest in bytes
+    const RIOT_ECC_PRIVATE *key             // IN:  Signing key
 );
 
 RIOT_STATUS
 RiotCrypt_Verify(
-    const void                 *data,       // IN: TODO
-    size_t                      dataSize,   // IN: TODO
-    const RIOT_ECC_SIGNATURE   *sig,        // IN: TODO
-    const RIOT_ECC_PUBLIC      *key         // IN: TODO
+    const void                 *data,       // IN: Data to verify signature of
+    size_t                      dataSize,   // IN: Size of data in bytes
+    const RIOT_ECC_SIGNATURE   *sig,        // IN: Signature to verify
+    const RIOT_ECC_PUBLIC      *key         // IN: ECC public key of signer
 );
 
 RIOT_STATUS
 RiotCrypt_VerifyDigest(
-    const uint8_t              *digest,     // IN: TODO
-    size_t                      digestSize, // IN: TODO
-    const RIOT_ECC_SIGNATURE   *sig,        // IN: TODO
-    const RIOT_ECC_PUBLIC      *key         // IN: TODO
+    const uint8_t              *digest,     // IN: Digest to verify signature of
+    size_t                      digestSize, // IN: Size of the digest
+    const RIOT_ECC_SIGNATURE   *sig,        // IN: Signature to verify
+    const RIOT_ECC_PUBLIC      *key         // IN: ECC public key of signer
 );
 
 RIOT_STATUS

--- a/Reference/RIoT/Core/RIoTCrypt/RiotCrypt.c
+++ b/Reference/RIoT/Core/RIoTCrypt/RiotCrypt.c
@@ -164,12 +164,12 @@ RiotCrypt_Hmac2(
 
 RIOT_STATUS
 RiotCrypt_DeriveEccKey(
-    RIOT_ECC_PUBLIC    *publicPart,     // OUT: TODO
-    RIOT_ECC_PRIVATE   *privatePart,    // OUT: TODO
-    const void         *srcData,        // IN:  TODO
-    size_t              srcDataSize,    // IN:  TODO
-    const uint8_t      *label,          // IN:  TODO
-    size_t              labelSize       // IN:  TODO
+    RIOT_ECC_PUBLIC    *publicPart,     // OUT: Derived public key
+    RIOT_ECC_PRIVATE   *privatePart,    // OUT: Derived private key
+    const void         *srcData,        // IN:  Initial data for derivation
+    size_t              srcDataSize,    // IN:  Size of the source data in bytes
+    const uint8_t      *label,          // IN:  Label for derivation (may be NULL)
+    size_t              labelSize       // IN:  Size of the label in bytes
 )
 {
     bigval_t    srcVal  = { 0 };
@@ -192,9 +192,9 @@ RiotCrypt_DeriveEccKey(
 
 void
 RiotCrypt_ExportEccPub(
-    RIOT_ECC_PUBLIC     *a,     // IN:  TODO
-    uint8_t             *b,     // OUT: TODO
-    uint32_t            *s      // OUT: TODO
+    RIOT_ECC_PUBLIC     *a,     // IN:  ECC public key to export
+    uint8_t             *b,     // OUT: Buffer to receive the public key
+    uint32_t            *s      // OUT: Pointer to receive the buffer size (may be NULL)
 )
 {
     *b++ = 0x04;
@@ -209,10 +209,10 @@ RiotCrypt_ExportEccPub(
 
 RIOT_STATUS
 RiotCrypt_Sign(
-    RIOT_ECC_SIGNATURE     *sig,        // OUT: TODO
-    const void             *data,       // IN:  TODO
-    size_t                  dataSize,   // IN:  TODO
-    const RIOT_ECC_PRIVATE *key         // IN:  TODO
+    RIOT_ECC_SIGNATURE     *sig,        // OUT: Signature of data
+    const void             *data,       // IN:  Data to sign
+    size_t                  dataSize,   // IN:  Data size in bytes
+    const RIOT_ECC_PRIVATE *key         // IN:  Signing key
 )
 {
     uint8_t digest[RIOT_DIGEST_LENGTH];
@@ -224,10 +224,10 @@ RiotCrypt_Sign(
 
 RIOT_STATUS
 RiotCrypt_SignDigest(
-    RIOT_ECC_SIGNATURE     *sig,            // OUT: TODO
-    const uint8_t          *digest,         // IN:  TODO
-    size_t                  digestSize,     // IN:  TODO
-    const RIOT_ECC_PRIVATE *key             // IN:  TODO
+    RIOT_ECC_SIGNATURE     *sig,            // OUT: Signature of digest
+    const uint8_t          *digest,         // IN:  Digest to sign
+    size_t                  digestSize,     // IN:  Size of the digest in bytes
+    const RIOT_ECC_PRIVATE *key             // IN:  Signing key
 )
 {
     if (digestSize != RIOT_DIGEST_LENGTH) {
@@ -239,10 +239,10 @@ RiotCrypt_SignDigest(
 
 RIOT_STATUS
 RiotCrypt_Verify(
-    const void                 *data,       // IN: TODO
-    size_t                      dataSize,   // IN: TODO
-    const RIOT_ECC_SIGNATURE   *sig,        // IN: TODO
-    const RIOT_ECC_PUBLIC      *key         // IN: TODO
+    const void                 *data,       // IN: Data to verify signature of
+    size_t                      dataSize,   // IN: Size of data in bytes
+    const RIOT_ECC_SIGNATURE   *sig,        // IN: Signature to verify
+    const RIOT_ECC_PUBLIC      *key         // IN: ECC public key of signer
 )
 {
     uint8_t digest[RIOT_DIGEST_LENGTH];
@@ -254,10 +254,10 @@ RiotCrypt_Verify(
 
 RIOT_STATUS
 RiotCrypt_VerifyDigest(
-    const uint8_t              *digest,     // IN: TODO
-    size_t                      digestSize, // IN: TODO
-    const RIOT_ECC_SIGNATURE   *sig,        // IN: TODO
-    const RIOT_ECC_PUBLIC      *key         // IN: TODO
+    const uint8_t              *digest,     // IN: Digest to verify signature of
+    size_t                      digestSize, // IN: Size of the digest
+    const RIOT_ECC_SIGNATURE   *sig,        // IN: Signature to verify
+    const RIOT_ECC_PUBLIC      *key         // IN: ECC public key of signer
 )
 {
     if (digestSize != RIOT_DIGEST_LENGTH) {

--- a/Reference/RIoT/Core/RIoTCrypt/include/RiotCrypt.h
+++ b/Reference/RIoT/Core/RIoTCrypt/include/RiotCrypt.h
@@ -134,51 +134,51 @@ RiotCrypt_Hmac2(
 
 RIOT_STATUS
 RiotCrypt_DeriveEccKey(
-    RIOT_ECC_PUBLIC    *publicPart,     // OUT: TODO
-    RIOT_ECC_PRIVATE   *privatePart,    // OUT: TODO
-    const void         *srcData,        // IN:  TODO
-    size_t              srcDataSize,    // IN:  TODO
-    const uint8_t      *label,          // IN:  TODO
-    size_t              labelSize       // IN:  TODO
+    RIOT_ECC_PUBLIC    *publicPart,     // OUT: Derived public key
+    RIOT_ECC_PRIVATE   *privatePart,    // OUT: Derived private key
+    const void         *srcData,        // IN:  Initial data for derivation
+    size_t              srcDataSize,    // IN:  Size of the source data in bytes
+    const uint8_t      *label,          // IN:  Label for derivation (may be NULL)
+    size_t              labelSize       // IN:  Size of the label in bytes
 );
 
 void
 RiotCrypt_ExportEccPub(
-    RIOT_ECC_PUBLIC     *a,     // IN:  TODO
-    uint8_t             *b,     // OUT: TODO
-    uint32_t            *s      // OUT: TODO
+    RIOT_ECC_PUBLIC     *a,     // IN:  ECC public key to export
+    uint8_t             *b,     // OUT: Buffer to receive the public key
+    uint32_t            *s      // OUT: Pointer to receive the buffer size (may be NULL)
 );
 
 RIOT_STATUS
 RiotCrypt_Sign(
-    RIOT_ECC_SIGNATURE     *sig,        // OUT: TODO
-    const void             *data,       // IN:  TODO
-    size_t                  dataSize,   // IN:  TODO
-    const RIOT_ECC_PRIVATE *key         // IN:  TODO
+    RIOT_ECC_SIGNATURE     *sig,        // OUT: Signature of data
+    const void             *data,       // IN:  Data to sign
+    size_t                  dataSize,   // IN:  Data size in bytes
+    const RIOT_ECC_PRIVATE *key         // IN:  Signing key
 );
 
 RIOT_STATUS
 RiotCrypt_SignDigest(
-    RIOT_ECC_SIGNATURE     *sig,            // OUT: TODO
-    const uint8_t          *digest,         // IN:  TODO
-    size_t                  digestSize,     // IN:  TODO
-    const RIOT_ECC_PRIVATE *key             // IN:  TODO
+    RIOT_ECC_SIGNATURE     *sig,            // OUT: Signature of digest
+    const uint8_t          *digest,         // IN:  Digest to sign
+    size_t                  digestSize,     // IN:  Size of the digest in bytes
+    const RIOT_ECC_PRIVATE *key             // IN:  Signing key
 );
 
 RIOT_STATUS
 RiotCrypt_Verify(
-    const void                 *data,       // IN: TODO
-    size_t                      dataSize,   // IN: TODO
-    const RIOT_ECC_SIGNATURE   *sig,        // IN: TODO
-    const RIOT_ECC_PUBLIC      *key         // IN: TODO
+    const void                 *data,       // IN: Data to verify signature of
+    size_t                      dataSize,   // IN: Size of data in bytes
+    const RIOT_ECC_SIGNATURE   *sig,        // IN: Signature to verify
+    const RIOT_ECC_PUBLIC      *key         // IN: ECC public key of signer
 );
 
 RIOT_STATUS
 RiotCrypt_VerifyDigest(
-    const uint8_t              *digest,     // IN: TODO
-    size_t                      digestSize, // IN: TODO
-    const RIOT_ECC_SIGNATURE   *sig,        // IN: TODO
-    const RIOT_ECC_PUBLIC      *key         // IN: TODO
+    const uint8_t              *digest,     // IN: Digest to verify signature of
+    size_t                      digestSize, // IN: Size of the digest
+    const RIOT_ECC_SIGNATURE   *sig,        // IN: Signature to verify
+    const RIOT_ECC_PUBLIC      *key         // IN: ECC public key of signer
 );
 
 RIOT_STATUS


### PR DESCRIPTION
In RiotCrypt, some of the ECC functions had their parameter documentation left as TODO. This PR fills those spots with appropriate documentation in both the Emulator and Reference versions of RiotCrypt.h and RiotCrypt.c