### PR TITLE
Adjust the parameter order to the RIOT_KDF_FIXED call in RiotCrypt.c

### DIFF
--- a/Emulator/RIoT/RIoTCrypt/RiotCrypt.c
+++ b/Emulator/RIoT/RIoTCrypt/RiotCrypt.c
@@ -41,8 +41,8 @@ RiotCrypt_Kdf(
         return RIOT_INVALID_PARAMETER;
     }
 
-    fixedSize = RIOT_KDF_FIXED(fixed, fixedSize, context, contextSize,
-                               label, labelSize, bytesToDerive * 8);
+    fixedSize = RIOT_KDF_FIXED(fixed, fixedSize, label, labelSize, 
+                               context, contextSize, bytesToDerive * 8);
 
     while (counter < (bytesToDerive / (RIOT_KEY_LENGTH))) {
 

--- a/Reference/RIoT/Core/RIoTCrypt/RiotCrypt.c
+++ b/Reference/RIoT/Core/RIoTCrypt/RiotCrypt.c
@@ -41,8 +41,8 @@ RiotCrypt_Kdf(
         return RIOT_INVALID_PARAMETER;
     }
 
-    fixedSize = RIOT_KDF_FIXED(fixed, fixedSize, context, contextSize,
-                               label, labelSize, bytesToDerive * 8);
+    fixedSize = RIOT_KDF_FIXED(fixed, fixedSize, label, labelSize,
+                               context, contextSize, bytesToDerive * 8);
 
     while (counter < (bytesToDerive / (RIOT_KEY_LENGTH))) {
 


### PR DESCRIPTION
In RiotKdf.h/c and in other calls to RIOT_KDF_FIXED the label & label_size parameters come before the context and context_size parameters. The calls in RiotCrypt.c (both in Emulator and Reference) are the only ones that differ in order. This PR adjusts them to have the same order as all the other references.