### PR TITLE
Fix environment detection and compile warning

### DIFF
--- a/CyReP/RiotAes128.c
+++ b/CyReP/RiotAes128.c
@@ -261,9 +261,4 @@ const char *modes[] = {
     ""
 };
 
-const char **riot_aes_modes(void)
-{
-    return &modes[0];
-}
-
 #endif

--- a/CyReP/RiotEcc.c
+++ b/CyReP/RiotEcc.c
@@ -1678,7 +1678,7 @@ ECC_feature_list(void)
 
 
 #ifdef USES_EPHEMERAL
-#if defined(CONFIG_CYREP_UBOOT_BUILD) || defined(CONFIG_CYREP_OPTEE_BUILD) || defined(CONFIG_CYREP_SGX_BUILD)
+#if defined(__UBOOT__) || defined(__KERNEL__) || defined(CONFIG_CYREP_SGX_BUILD)
 COND_STATIC int
 get_random_bytes(uint8_t *buf, size_t len)
 {

--- a/CyReP/cyrep/RiotTarget.h
+++ b/CyReP/cyrep/RiotTarget.h
@@ -36,26 +36,14 @@ typedef unsigned long long uint64_t;  // 64-bit unsigned integer
 
 #elif defined(__GNUC__)
 
-#if defined(CONFIG_CYREP_UBOOT_BUILD)
+#if defined(__UBOOT__)
 #include <common.h>
-#define CYREP_PLATFORM_TRACE_ERROR printf
 
-#elif defined(CONFIG_CYREP_OPTEE_BUILD)
+#elif defined(__KERNEL__) /* OP-TEE */
 #include <stdint.h>
 #include <types_ext.h>
 #include <string.h>
 #include <assert.h>
-#define CYREP_PLATFORM_TRACE_ERROR EMSG
-
-#elif defined(CONFIG_CYREP_UEFI_BUILD)
-#include <stdbool.h>
-#include <stdint.h>
-#include <stddef.h>
-#include <assert.h>
-#include <string.h>
-#include <Library/DebugLib.h>
-#define CYREP_PLATFORM_TRACE_ERROR(...) \
-    DEBUG((DEBUG_ERROR, __VA_ARGS__))
 
 #elif defined(STM32L476xx) || defined(STM32L4A6xx)
 #include <string.h>


### PR DESCRIPTION
Simplify environment detection so that U-Boot and OPTEE don't need to define unnecessary symbols. Use provided defines `__UBOOT__` and `__KERNEL__`.

Remove an unreferenced symbol to fix compile error in OPTEE.