### PR TITLE
Fix environment detection and compile warning

### DIFF
--- a/CyReP/RiotAes128.c
+++ b/CyReP/RiotAes128.c
@@ -261,9 +261,4 @@ const char *modes[] = {
     ""
 };
 
-const char **riot_aes_modes(void)
-{
-    return &modes[0];
-}
-
 #endif

--- a/CyReP/RiotBase64.c
+++ b/CyReP/RiotBase64.c
@@ -228,7 +228,7 @@ Base64Decode(
 
 uint32_t Base64Length(uint32_t ByteCount)
 {
-	uint32_t reqLen;
+	uint32_t reqLen = 0;
 	Base64Encode(NULL, ByteCount, NULL, &reqLen);
 	return reqLen;
 }

--- a/CyReP/RiotEcc.c
+++ b/CyReP/RiotEcc.c
@@ -1678,7 +1678,7 @@ ECC_feature_list(void)
 
 
 #ifdef USES_EPHEMERAL
-#if defined(CONFIG_CYREP_UBOOT_BUILD) || defined(CONFIG_CYREP_OPTEE_BUILD) || defined(CONFIG_CYREP_SGX_BUILD)
+#if defined(__UBOOT__) || defined(__OPTEE__) || defined(CONFIG_CYREP_SGX_BUILD)
 COND_STATIC int
 get_random_bytes(uint8_t *buf, size_t len)
 {

--- a/CyReP/cyrep/RiotTarget.h
+++ b/CyReP/cyrep/RiotTarget.h
@@ -36,26 +36,18 @@ typedef unsigned long long uint64_t;  // 64-bit unsigned integer
 
 #elif defined(__GNUC__)
 
-#if defined(CONFIG_CYREP_UBOOT_BUILD)
-#include <common.h>
-#define CYREP_PLATFORM_TRACE_ERROR printf
+#ifdef CFG_OPTEE_REVISION_MAJOR
+#define __OPTEE__
+#endif
 
-#elif defined(CONFIG_CYREP_OPTEE_BUILD)
+#if defined(__UBOOT__)
+#include <common.h>
+
+#elif defined(__OPTEE__)
 #include <stdint.h>
 #include <types_ext.h>
 #include <string.h>
 #include <assert.h>
-#define CYREP_PLATFORM_TRACE_ERROR EMSG
-
-#elif defined(CONFIG_CYREP_UEFI_BUILD)
-#include <stdbool.h>
-#include <stdint.h>
-#include <stddef.h>
-#include <assert.h>
-#include <string.h>
-#include <Library/DebugLib.h>
-#define CYREP_PLATFORM_TRACE_ERROR(...) \
-    DEBUG((DEBUG_ERROR, __VA_ARGS__))
 
 #elif defined(STM32L476xx) || defined(STM32L4A6xx)
 #include <string.h>


### PR DESCRIPTION
Simplify environment detection so that U-Boot and OPTEE don't need to define unnecessary symbols. Use provided defines `__UBOOT__` and `CFG_OPTEE_REVISION_MAJOR`.

Remove an unreferenced symbol to fix compile error in OPTEE. The string `riot_aes_modes` does not appear anywhere else in this repository.

@Britel 