### PR TITLE
Fix spelling typos, indentation and add GetClaim.

### DIFF
--- a/CyReP/RiotDerEnc.c
+++ b/CyReP/RiotDerEnc.c
@@ -90,7 +90,7 @@ DERInitContext(
     uint8_t             *Buffer,
     uint32_t             Length
 )
-// Intialize the builder context.  The caller manages the encoding buffer.
+// Initialize the builder context.  The caller manages the encoding buffer.
 // Note that the encoding routines do conservative checks that the encoding
 // will fit, so approximately 30 extra bytes are needed.  Note that if an
 // encoding routine fails because the buffer is too small, the buffer will

--- a/CyReP/RiotX509Bldr.c
+++ b/CyReP/RiotX509Bldr.c
@@ -85,67 +85,67 @@ X509AddExtensions(
     CHK(        DERPopNesting(Tbs));
     if (PathLen >= 0)
     {
-        CHK(        DERStartSequenceOrSet(Tbs, true));
-        CHK(            DERAddOID(Tbs, basicConstraintsOID));
-        CHK(            DERAddBoolean(Tbs, true));
-        CHK(            DERStartEnvelopingOctetString(Tbs));
-        CHK(                DERStartSequenceOrSet(Tbs, true));
+        CHK(    DERStartSequenceOrSet(Tbs, true));
+        CHK(        DERAddOID(Tbs, basicConstraintsOID));
+        CHK(        DERAddBoolean(Tbs, true));
+        CHK(        DERStartEnvelopingOctetString(Tbs));
+        CHK(            DERStartSequenceOrSet(Tbs, true));
         if (PathLen > 0)
         {
-            CHK(                DERAddBoolean(Tbs, true));
-            CHK(                DERAddInteger(Tbs, PathLen));
+            CHK(        DERAddBoolean(Tbs, true));
+            CHK(        DERAddInteger(Tbs, PathLen));
         }
         else
         {
-            CHK(                DERAddBoolean(Tbs, false));
+            CHK(        DERAddBoolean(Tbs, false));
         }
-        CHK(                DERPopNesting(Tbs));
         CHK(            DERPopNesting(Tbs));
         CHK(        DERPopNesting(Tbs));
+        CHK(    DERPopNesting(Tbs));
     }
     if (PathLen > 0)
     {
-        CHK(        DERStartSequenceOrSet(Tbs, true));
-        CHK(            DERAddOID(Tbs, keyUsageOID));
-        CHK(            DERStartEnvelopingOctetString(Tbs));
-        CHK(                DERAddBitString(Tbs, keyUsageCA, sizeof(keyUsageCA)));
-        CHK(            DERPopNesting(Tbs));
+        CHK(    DERStartSequenceOrSet(Tbs, true));
+        CHK(        DERAddOID(Tbs, keyUsageOID));
+        CHK(        DERStartEnvelopingOctetString(Tbs));
+        CHK(            DERAddBitString(Tbs, keyUsageCA, sizeof(keyUsageCA)));
         CHK(        DERPopNesting(Tbs));
+        CHK(    DERPopNesting(Tbs));
     }
     else
     {
-        CHK(        DERStartSequenceOrSet(Tbs, true));
-        CHK(            DERAddOID(Tbs, extKeyUsageOID));
-        CHK(            DERAddBoolean(Tbs, true));
-        CHK(            DERStartEnvelopingOctetString(Tbs));
-        CHK(                DERStartSequenceOrSet(Tbs, true));
-        CHK(                    DERAddOID(Tbs, clientAuthOID));
-        CHK(                    DERAddOID(Tbs, serverAuthOID));
-        CHK(                DERPopNesting(Tbs));
+        CHK(    DERStartSequenceOrSet(Tbs, true));
+        CHK(        DERAddOID(Tbs, extKeyUsageOID));
+        CHK(        DERAddBoolean(Tbs, true));
+        CHK(        DERStartEnvelopingOctetString(Tbs));
+        CHK(            DERStartSequenceOrSet(Tbs, true));
+        CHK(                DERAddOID(Tbs, clientAuthOID));
+        CHK(                DERAddOID(Tbs, serverAuthOID));
         CHK(            DERPopNesting(Tbs));
         CHK(        DERPopNesting(Tbs));
+        CHK(    DERPopNesting(Tbs));
     }
     if (TcpsLen == 0 && ExtensionBufferSize == 0) // riotOID
     {
-        CHK(        DERStartSequenceOrSet(Tbs, true));
-        CHK(            DERAddOID(Tbs, riotOID));
-        CHK(            DERStartEnvelopingOctetString(Tbs));
+        CHK(    DERStartSequenceOrSet(Tbs, true));
+        CHK(        DERAddOID(Tbs, riotOID));
+        CHK(        DERStartEnvelopingOctetString(Tbs));
+        CHK(            DERStartSequenceOrSet(Tbs, true));
+        CHK(                DERAddInteger(Tbs, 1));
         CHK(                DERStartSequenceOrSet(Tbs, true));
-        CHK(                    DERAddInteger(Tbs, 1));
         CHK(                    DERStartSequenceOrSet(Tbs, true));
-        CHK(                        DERStartSequenceOrSet(Tbs, true));
-        CHK(                            DERAddOID(Tbs, ecPublicKeyOID));
-        CHK(                            DERAddOID(Tbs, prime256v1OID));
-        CHK(                        DERPopNesting(Tbs));
-        CHK(                        DERAddBitString(Tbs, DevIdPub, DevIdPubLen));
+        CHK(                        DERAddOID(Tbs, ecPublicKeyOID));
+        CHK(                        DERAddOID(Tbs, prime256v1OID));
         CHK(                    DERPopNesting(Tbs));
-        CHK(                    DERStartSequenceOrSet(Tbs, true));
-        CHK(                        DERAddOID(Tbs, sha256OID));
-        CHK(                        DERAddOctetString(Tbs, Fwid, FwidLen));
-        CHK(                    DERPopNesting(Tbs));
+        CHK(                    DERAddBitString(Tbs, DevIdPub, DevIdPubLen));
+        CHK(                DERPopNesting(Tbs));
+        CHK(                DERStartSequenceOrSet(Tbs, true));
+        CHK(                    DERAddOID(Tbs, sha256OID));
+        CHK(                    DERAddOctetString(Tbs, Fwid, FwidLen));
         CHK(                DERPopNesting(Tbs));
         CHK(            DERPopNesting(Tbs));
         CHK(        DERPopNesting(Tbs));
+        CHK(    DERPopNesting(Tbs));
     }
     else if (ExtensionBufferSize == 0) // tcpsOID
     {
@@ -230,7 +230,7 @@ X509GetDeviceCertTBS(
     uint32_t    encBufferLen;
     uint8_t     keyId[RIOT_DIGEST_LENGTH];
     uint8_t     issuerKeyId[RIOT_DIGEST_LENGTH];
-	uint8_t     keyUsageCA[] = RIOT_X509_CA_KEY_USAGE;
+    uint8_t     keyUsageCA[] = RIOT_X509_CA_KEY_USAGE;
 
     if (IssuerIdKeyPub != NULL)
     {

--- a/CyReP/tcps/TcpsId.h
+++ b/CyReP/tcps/TcpsId.h
@@ -87,6 +87,15 @@ ModifyDeviceClaim(
     uint32_t *Written
 );
 
+RIOT_STATUS
+GetClaim(
+    const uint8_t* Id,
+    uint32_t IdSize,
+    const char* Name,
+    const uint8_t** Value,
+    size_t* ValueSize
+);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This change is needed to support oe_parse_report OPTEE implementation.

This change addresses spelling typos, changes DER indentation for easier readability, fixes some const usage and implements GetClaim function.